### PR TITLE
feat: WWWAuthenticate header can be removed from webdav server response

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -63,14 +63,15 @@ var (
 		Debug:                      false,
 	}
 	defaultWebDAVDBinding = webdavd.Binding{
-		Address:         "",
-		Port:            0,
-		EnableHTTPS:     false,
-		MinTLSVersion:   12,
-		ClientAuthType:  0,
-		TLSCipherSuites: nil,
-		Prefix:          "",
-		ProxyAllowed:    nil,
+		Address:           "",
+		Port:              0,
+		EnableHTTPS:       false,
+		MinTLSVersion:     12,
+		ClientAuthType:    0,
+		TLSCipherSuites:   nil,
+		Prefix:            "",
+		ProxyAllowed:      nil,
+		RemoveWAuthHeader: false,
 	}
 	defaultHTTPDBinding = httpd.Binding{
 		Address:               "",

--- a/sftpgo.json
+++ b/sftpgo.json
@@ -38,12 +38,7 @@
         "period": 1000,
         "burst": 1,
         "type": 2,
-        "protocols": [
-          "SSH",
-          "FTP",
-          "DAV",
-          "HTTP"
-        ],
+        "protocols": ["SSH", "FTP", "DAV", "HTTP"],
         "allow_list": [],
         "generate_defender_events": false,
         "entries_soft_limit": 100,
@@ -67,13 +62,7 @@
     "macs": [],
     "trusted_user_ca_keys": [],
     "login_banner_file": "",
-    "enabled_ssh_commands": [
-      "md5sum",
-      "sha1sum",
-      "cd",
-      "pwd",
-      "scp"
-    ],
+    "enabled_ssh_commands": ["md5sum", "sha1sum", "cd", "pwd", "scp"],
     "keyboard_interactive_authentication": false,
     "keyboard_interactive_auth_hook": "",
     "password_authentication": true,
@@ -122,7 +111,8 @@
         "client_auth_type": 0,
         "tls_cipher_suites": [],
         "prefix": "",
-        "proxy_allowed": []
+        "proxy_allowed": [],
+        "remove_w_auth_header": true
       }
     ],
     "certificate_file": "",

--- a/webdavd/server.go
+++ b/webdavd/server.go
@@ -170,7 +170,9 @@ func (s *webDavServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	user, isCached, lockSystem, loginMethod, err := s.authenticate(r, ipAddr)
 	if err != nil {
 		updateLoginMetrics(&user, ipAddr, loginMethod, err)
-		w.Header().Set("WWW-Authenticate", "Basic realm=\"SFTPGo WebDAV\"")
+		if !s.binding.RemoveWAuthHeader {
+			w.Header().Set("WWW-Authenticate", "Basic realm=\"SFTPGo WebDAV\"")
+		}
 		http.Error(w, fmt.Sprintf("Authentication error: %v", err), http.StatusUnauthorized)
 		return
 	}

--- a/webdavd/webdavd.go
+++ b/webdavd/webdavd.go
@@ -95,6 +95,7 @@ type Binding struct {
 	// List of IP addresses and IP ranges allowed to set X-Forwarded-For/X-Real-IP headers.
 	ProxyAllowed     []string `json:"proxy_allowed" mapstructure:"proxy_allowed"`
 	allowHeadersFrom []func(net.IP) bool
+	RemoveWAuthHeader     bool `json:"remove_w_auth_header" mapstructure:"remove_w_auth_header"`
 }
 
 func (b *Binding) parseAllowedProxy() error {


### PR DESCRIPTION
Adds a RemoveWAuthHeader(bool) option in webdav bindings option